### PR TITLE
fix: resolve all lint errors in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 """Pytest configuration and shared fixtures."""
 
-import pytest
 from pathlib import Path
+
+import pytest
 
 # Sample diffs for testing
 SAMPLE_SECURE_DIFF = """\

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,7 +1,8 @@
 """Tests for review agents."""
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 class TestCursorClient:
@@ -32,9 +33,7 @@ class TestCursorClient:
 
         # Mock the HTTP client
         mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "choices": [{"message": {"content": "Review response"}}]
-        }
+        mock_response.json.return_value = {"choices": [{"message": {"content": "Review response"}}]}
         mock_response.raise_for_status = MagicMock()
 
         with patch.object(client._client, "post", new_callable=AsyncMock) as mock_post:
@@ -56,9 +55,9 @@ class TestSecurityAgent:
     @pytest.mark.asyncio
     async def test_detects_sql_injection(self, sample_vulnerable_diff, mock_review_context):
         """Test that security agent detects SQL injection."""
-        from ai_reviewer.agents.security import SecurityAgent
         from ai_reviewer.agents.cursor_client import CursorClient, CursorConfig
-        from ai_reviewer.models.findings import Severity, Category
+        from ai_reviewer.agents.security import SecurityAgent
+        from ai_reviewer.models.findings import Severity
 
         # Create agent with mocked client
         config = CursorConfig(api_key="test-key")
@@ -96,19 +95,15 @@ class TestSecurityAgent:
 
             assert len(review.findings) >= 1
             # Should find the SQL injection
-            sql_findings = [
-                f for f in review.findings if "sql" in f.title.lower()
-            ]
+            sql_findings = [f for f in review.findings if "sql" in f.title.lower()]
             assert len(sql_findings) >= 1
             assert sql_findings[0].severity == Severity.CRITICAL
 
     @pytest.mark.asyncio
-    async def test_no_false_positives_on_safe_code(
-        self, sample_secure_diff, mock_review_context
-    ):
+    async def test_no_false_positives_on_safe_code(self, sample_secure_diff, mock_review_context):
         """Test that security agent doesn't flag safe code."""
-        from ai_reviewer.agents.security import SecurityAgent
         from ai_reviewer.agents.cursor_client import CursorClient, CursorConfig
+        from ai_reviewer.agents.security import SecurityAgent
 
         config = CursorConfig(api_key="test-key")
         client = CursorClient(config)
@@ -131,9 +126,7 @@ class TestSecurityAgent:
             )
 
             # Should not have critical findings for safe code
-            critical_findings = [
-                f for f in review.findings if f.severity.value == "critical"
-            ]
+            critical_findings = [f for f in review.findings if f.severity.value == "critical"]
             assert len(critical_findings) == 0
 
 
@@ -141,12 +134,10 @@ class TestPerformanceAgent:
     """Tests for the performance-focused review agent."""
 
     @pytest.mark.asyncio
-    async def test_detects_on2_complexity(
-        self, sample_performance_diff, mock_review_context
-    ):
+    async def test_detects_on2_complexity(self, sample_performance_diff, mock_review_context):
         """Test that performance agent detects O(n²) loops."""
-        from ai_reviewer.agents.performance import PerformanceAgent
         from ai_reviewer.agents.cursor_client import CursorClient, CursorConfig
+        from ai_reviewer.agents.performance import PerformanceAgent
         from ai_reviewer.models.findings import Category
 
         config = CursorConfig(api_key="test-key")
@@ -181,7 +172,5 @@ class TestPerformanceAgent:
                 context=mock_review_context,
             )
 
-            perf_findings = [
-                f for f in review.findings if f.category == Category.PERFORMANCE
-            ]
+            perf_findings = [f for f in review.findings if f.category == Category.PERFORMANCE]
             assert len(perf_findings) >= 1

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,17 +1,14 @@
 """Tests for the review aggregator."""
 
-import pytest
-from datetime import datetime
-
 
 class TestReviewAggregator:
     """Tests for ReviewAggregator."""
 
     def test_deduplicates_identical_findings(self):
         """Test that identical findings from multiple agents are merged."""
-        from ai_reviewer.orchestrator.aggregator import ReviewAggregator
+        from ai_reviewer.models.findings import Category, ReviewFinding, Severity
         from ai_reviewer.models.review import AgentReview
-        from ai_reviewer.models.findings import ReviewFinding, Severity, Category
+        from ai_reviewer.orchestrator.aggregator import ReviewAggregator
 
         # Same finding from two agents
         finding_1 = ReviewFinding(
@@ -66,9 +63,9 @@ class TestReviewAggregator:
 
     def test_keeps_unique_findings_separate(self):
         """Test that different findings remain separate."""
-        from ai_reviewer.orchestrator.aggregator import ReviewAggregator
+        from ai_reviewer.models.findings import Category, ReviewFinding, Severity
         from ai_reviewer.models.review import AgentReview
-        from ai_reviewer.models.findings import ReviewFinding, Severity, Category
+        from ai_reviewer.orchestrator.aggregator import ReviewAggregator
 
         finding_security = ReviewFinding(
             file_path="auth/login.py",
@@ -122,9 +119,9 @@ class TestReviewAggregator:
 
     def test_priority_ranking(self):
         """Test that findings are ranked by severity × consensus."""
-        from ai_reviewer.orchestrator.aggregator import ReviewAggregator
+        from ai_reviewer.models.findings import Category, ReviewFinding, Severity
         from ai_reviewer.models.review import AgentReview
-        from ai_reviewer.models.findings import ReviewFinding, Severity, Category
+        from ai_reviewer.orchestrator.aggregator import ReviewAggregator
 
         # Critical finding with partial consensus
         critical_partial = ReviewFinding(
@@ -179,9 +176,9 @@ class TestReviewAggregator:
 
     def test_computes_review_quality_score(self):
         """Test that overall review quality score is computed."""
-        from ai_reviewer.orchestrator.aggregator import ReviewAggregator
+        from ai_reviewer.models.findings import Category, ReviewFinding, Severity
         from ai_reviewer.models.review import AgentReview
-        from ai_reviewer.models.findings import ReviewFinding, Severity, Category
+        from ai_reviewer.orchestrator.aggregator import ReviewAggregator
 
         finding = ReviewFinding(
             file_path="test.py",
@@ -216,8 +213,8 @@ class TestReviewAggregator:
 
     def test_handles_empty_reviews(self):
         """Test aggregating reviews with no findings."""
-        from ai_reviewer.orchestrator.aggregator import ReviewAggregator
         from ai_reviewer.models.review import AgentReview
+        from ai_reviewer.orchestrator.aggregator import ReviewAggregator
 
         review_1 = AgentReview(
             agent_id="agent-1",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,8 @@
 """Tests for CLI commands."""
 
-import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
 from click.testing import CliRunner
-from unittest.mock import patch, AsyncMock, MagicMock
 
 
 class TestCLI:
@@ -31,7 +31,7 @@ class TestCLI:
                 agent_count=3,
             )
 
-            result = runner.invoke(
+            runner.invoke(
                 cli,
                 ["review-pr", "test-org/test-repo", "42"],
                 catch_exceptions=False,
@@ -56,7 +56,7 @@ class TestCLI:
                 agent_count=3,
             )
 
-            result = runner.invoke(
+            runner.invoke(
                 cli,
                 ["review-pr", "test-org/test-repo", "42", "--dry-run"],
             )
@@ -121,7 +121,7 @@ class TestCLI:
 
         with patch("ai_reviewer.cli.uvicorn") as mock_uvicorn:
             # Don't actually start server, just verify it would be called
-            result = runner.invoke(
+            runner.invoke(
                 cli,
                 ["serve", "--port", "9000", "--host", "127.0.0.1"],
                 catch_exceptions=False,
@@ -161,7 +161,7 @@ index 1234567..abcdefg 100644
                 agent_count=3,
             )
 
-            result = runner.invoke(
+            runner.invoke(
                 cli,
                 ["review", "--output", "markdown"],
                 input=sample_diff,
@@ -190,7 +190,7 @@ index 1234567..abcdefg 100644
                     agent_count=3,
                 )
 
-                result = runner.invoke(
+                runner.invoke(
                     cli,
                     ["review", "--diff", "changes.patch"],
                 )

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,7 +1,8 @@
 """Tests for GitHub integration."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from unittest.mock import MagicMock, patch, AsyncMock
 
 
 class TestGitHubClient:
@@ -22,7 +23,7 @@ class TestGitHubClient:
             )
         ]
 
-        with patch("ai_reviewer.github.client.Github") as mock_github:
+        with patch("ai_reviewer.github.client.Github"):
             client = GitHubClient(token="test-token")
             diff = client.get_pr_diff(mock_pr)
 
@@ -32,7 +33,6 @@ class TestGitHubClient:
     def test_builds_review_context(self):
         """Test building review context from PR."""
         from ai_reviewer.github.client import GitHubClient
-        from ai_reviewer.models.context import ReviewContext
 
         mock_pr = MagicMock()
         mock_pr.number = 42
@@ -66,7 +66,7 @@ class TestGitHubPRHandler:
     @pytest.mark.asyncio
     async def test_handles_pr_opened_event(self):
         """Test handling PR opened webhook event."""
-        from ai_reviewer.github.webhook import handle_pr_event, PREvent
+        from ai_reviewer.github.webhook import PREvent, handle_pr_event
 
         event = PREvent(
             repo="test-org/test-repo",
@@ -84,7 +84,7 @@ class TestGitHubPRHandler:
     @pytest.mark.asyncio
     async def test_ignores_irrelevant_actions(self):
         """Test that irrelevant PR actions are ignored."""
-        from ai_reviewer.github.webhook import handle_pr_event, PREvent
+        from ai_reviewer.github.webhook import PREvent, handle_pr_event
 
         event = PREvent(
             repo="test-org/test-repo",
@@ -102,10 +102,11 @@ class TestReviewFormatter:
 
     def test_formats_critical_findings(self):
         """Test formatting critical findings for GitHub."""
-        from ai_reviewer.github.formatter import GitHubFormatter
-        from ai_reviewer.models.review import ConsolidatedReview
-        from ai_reviewer.models.findings import ConsolidatedFinding, Severity, Category
         from datetime import datetime
+
+        from ai_reviewer.github.formatter import GitHubFormatter
+        from ai_reviewer.models.findings import Category, ConsolidatedFinding, Severity
+        from ai_reviewer.models.review import ConsolidatedReview
 
         findings = [
             ConsolidatedFinding(
@@ -150,9 +151,10 @@ class TestReviewFormatter:
 
     def test_formats_empty_review(self):
         """Test formatting review with no findings."""
+        from datetime import datetime
+
         from ai_reviewer.github.formatter import GitHubFormatter
         from ai_reviewer.models.review import ConsolidatedReview
-        from datetime import datetime
 
         review = ConsolidatedReview(
             id="review-123",
@@ -174,10 +176,11 @@ class TestReviewFormatter:
 
     def test_determines_review_action(self):
         """Test determining GitHub review action based on findings."""
-        from ai_reviewer.github.formatter import GitHubFormatter
-        from ai_reviewer.models.review import ConsolidatedReview
-        from ai_reviewer.models.findings import ConsolidatedFinding, Severity, Category
         from datetime import datetime
+
+        from ai_reviewer.github.formatter import GitHubFormatter
+        from ai_reviewer.models.findings import Category, ConsolidatedFinding, Severity
+        from ai_reviewer.models.review import ConsolidatedReview
 
         formatter = GitHubFormatter()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,5 @@
 """Tests for data models."""
 
-import pytest
 from datetime import datetime
 
 
@@ -10,7 +9,7 @@ class TestReviewFinding:
     def test_finding_creation(self):
         """Test creating a basic finding."""
         # Will test once models are implemented
-        from ai_reviewer.models.findings import ReviewFinding, Severity, Category
+        from ai_reviewer.models.findings import Category, ReviewFinding, Severity
 
         finding = ReviewFinding(
             file_path="auth/login.py",
@@ -30,7 +29,7 @@ class TestReviewFinding:
 
     def test_finding_without_suggested_fix(self):
         """Test finding without a suggested fix."""
-        from ai_reviewer.models.findings import ReviewFinding, Severity, Category
+        from ai_reviewer.models.findings import Category, ReviewFinding, Severity
 
         finding = ReviewFinding(
             file_path="utils/helper.py",
@@ -53,8 +52,8 @@ class TestAgentReview:
 
     def test_agent_review_creation(self):
         """Test creating an agent review."""
+        from ai_reviewer.models.findings import Category, ReviewFinding, Severity
         from ai_reviewer.models.review import AgentReview
-        from ai_reviewer.models.findings import ReviewFinding, Severity, Category
 
         findings = [
             ReviewFinding(
@@ -89,12 +88,12 @@ class TestConsolidatedReview:
 
     def test_consolidated_review_statistics(self):
         """Test that consolidated review computes statistics correctly."""
-        from ai_reviewer.models.review import ConsolidatedReview
         from ai_reviewer.models.findings import (
+            Category,
             ConsolidatedFinding,
             Severity,
-            Category,
         )
+        from ai_reviewer.models.review import ConsolidatedReview
 
         findings = [
             ConsolidatedFinding(

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,9 +1,10 @@
 """Tests for the agent orchestrator."""
 
-import pytest
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
 from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
 
 
 class TestAgentOrchestrator:
@@ -12,9 +13,8 @@ class TestAgentOrchestrator:
     @pytest.mark.asyncio
     async def test_parallel_execution(self, sample_vulnerable_diff, mock_review_context):
         """Test that agents are executed in parallel."""
-        from ai_reviewer.orchestrator.orchestrator import AgentOrchestrator
         from ai_reviewer.models.review import AgentReview
-        from ai_reviewer.models.findings import ReviewFinding, Severity, Category
+        from ai_reviewer.orchestrator.orchestrator import AgentOrchestrator
 
         # Create mock agents
         mock_agent_1 = MagicMock()
@@ -28,7 +28,7 @@ class TestAgentOrchestrator:
         # Track execution times to verify parallelism
         execution_times = []
 
-        async def mock_review_1(*args, **kwargs):
+        async def mock_review_1(*_args, **_kwargs):
             start = datetime.now()
             await asyncio.sleep(0.1)  # Simulate work
             execution_times.append(("agent-1", start, datetime.now()))
@@ -41,7 +41,7 @@ class TestAgentOrchestrator:
                 review_time_ms=100,
             )
 
-        async def mock_review_2(*args, **kwargs):
+        async def mock_review_2(*_args, **_kwargs):
             start = datetime.now()
             await asyncio.sleep(0.1)  # Simulate work
             execution_times.append(("agent-2", start, datetime.now()))
@@ -81,8 +81,8 @@ class TestAgentOrchestrator:
     @pytest.mark.asyncio
     async def test_handles_agent_timeout(self, sample_vulnerable_diff, mock_review_context):
         """Test that orchestrator handles agent timeouts gracefully."""
-        from ai_reviewer.orchestrator.orchestrator import AgentOrchestrator
         from ai_reviewer.models.review import AgentReview
+        from ai_reviewer.orchestrator.orchestrator import AgentOrchestrator
 
         # Create mock agents - one fast, one slow
         fast_agent = MagicMock()
@@ -93,7 +93,7 @@ class TestAgentOrchestrator:
         slow_agent.agent_id = "slow-agent"
         slow_agent.focus_areas = ["performance"]
 
-        async def fast_review(*args, **kwargs):
+        async def fast_review(*_args, **_kwargs):
             await asyncio.sleep(0.01)
             return AgentReview(
                 agent_id="fast-agent",
@@ -104,7 +104,7 @@ class TestAgentOrchestrator:
                 review_time_ms=10,
             )
 
-        async def slow_review(*args, **kwargs):
+        async def slow_review(*_args, **_kwargs):
             await asyncio.sleep(10)  # Will timeout
             return AgentReview(
                 agent_id="slow-agent",
@@ -135,9 +135,7 @@ class TestAgentOrchestrator:
         assert any(r.agent_id == "fast-agent" for r in results)
 
     @pytest.mark.asyncio
-    async def test_fails_if_insufficient_agents(
-        self, sample_vulnerable_diff, mock_review_context
-    ):
+    async def test_fails_if_insufficient_agents(self, sample_vulnerable_diff, mock_review_context):
         """Test that orchestrator fails if too few agents succeed."""
         from ai_reviewer.orchestrator.orchestrator import (
             AgentOrchestrator,
@@ -149,7 +147,7 @@ class TestAgentOrchestrator:
         failing_agent.agent_id = "failing-agent"
         failing_agent.focus_areas = ["security"]
 
-        async def failing_review(*args, **kwargs):
+        async def failing_review(*_args, **_kwargs):
             raise Exception("Agent failed")
 
         failing_agent.review = failing_review


### PR DESCRIPTION
## Summary

Fixes all ruff lint errors in the test suite.

## Changes

- **Import ordering (I001)**: Sorted imports alphabetically per isort rules
- **Unused imports (F401)**: Removed `pytest`, `datetime`, `Category`, `ReviewContext`, etc.
- **Unused variables (F841)**: Removed unused `result` assignments in CLI tests
- **Unused arguments (ARG001)**: Prefixed unused mock function arguments with `_` (`*_args, **_kwargs`)
- **Formatting**: Applied ruff formatter

## Verification

```bash
ruff check src/ tests/  # All checks passed!
ruff format --check src/ tests/  # All files formatted
```

## Files Modified

- `tests/conftest.py`
- `tests/test_agents.py`
- `tests/test_aggregator.py`
- `tests/test_cli.py`
- `tests/test_github.py`
- `tests/test_models.py`
- `tests/test_orchestrator.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test-only import cleanup and formatting, with minor adjustments to unused variables/arguments that shouldn’t affect runtime behavior.
> 
> **Overview**
> Cleans up the test suite to satisfy ruff/isort/formatter rules by reordering/removing imports, tightening formatting, and simplifying a few list comprehensions.
> 
> Eliminates unused variables (e.g., dropping unused `result` assignments in CLI tests) and unused parameters in async mocks by switching to `*_args, **_kwargs`, keeping test intent the same while removing lint noise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecf1c040813a8ea8446077156083f2fd2e1feed2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->