### PR TITLE
feat: remove Shannon entropy secret detection

### DIFF
--- a/src/ai_reviewer/security/scanner.py
+++ b/src/ai_reviewer/security/scanner.py
@@ -1,4 +1,4 @@
-"""Regex + entropy-based secret scanner that runs before LLM agents.
+"""Regex-based secret scanner that runs before LLM agents.
 
 Scans unified diffs for potential secrets on added lines only. Produces
 ConsolidatedFinding objects with severity=CRITICAL and category=SECURITY
@@ -9,9 +9,7 @@ from __future__ import annotations
 
 import fnmatch
 import logging
-import math
 import re
-from collections import Counter
 
 from ai_reviewer.models.findings import Category, ConsolidatedFinding, Severity
 
@@ -65,29 +63,8 @@ SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     ),
 ]
 
-_ENTROPY_MIN_LENGTH = 20
-_ENTROPY_THRESHOLD = 4.5
-
 _HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
 _DIFF_FILE_RE = re.compile(r"^\+\+\+ b/(.+)$")
-
-
-def _shannon_entropy(s: str) -> float:
-    """Compute Shannon entropy (bits) of a string."""
-    if not s:
-        return 0.0
-    counts = Counter(s)
-    length = len(s)
-    return -sum((count / length) * math.log2(count / length) for count in counts.values())
-
-
-def _extract_high_entropy_tokens(line: str) -> list[str]:
-    """Extract tokens from a line that look like potential secrets (alphanumeric runs)."""
-    return [
-        tok
-        for tok in re.findall(rf"[A-Za-z0-9/+=_\-]{{{_ENTROPY_MIN_LENGTH},}}", line)
-        if _shannon_entropy(tok) > _ENTROPY_THRESHOLD
-    ]
 
 
 def _file_matches_exclude(file_path: str, exclude_patterns: list[str]) -> bool:
@@ -172,34 +149,6 @@ def scan_for_secrets(
                         confidence=0.95,
                     )
                 )
-
-        high_entropy_tokens = _extract_high_entropy_tokens(added_content)
-        for token in high_entropy_tokens:
-            dedup_key = f"{current_file}:{current_line}:entropy:{token[:12]}"
-            if dedup_key in seen_keys:
-                continue
-            seen_keys.add(dedup_key)
-
-            finding_counter += 1
-            findings.append(
-                ConsolidatedFinding(
-                    id=f"secret-{finding_counter}",
-                    file_path=current_file,
-                    line_start=current_line,
-                    line_end=None,
-                    severity=Severity.CRITICAL,
-                    category=Category.SECURITY,
-                    title="High-entropy string detected (possible secret)",
-                    description=(
-                        f"A high-entropy string (Shannon entropy > {_ENTROPY_THRESHOLD}) "
-                        "was found on an added line, which may be a hardcoded secret or key."
-                    ),
-                    suggested_fix="Remove the hardcoded secret; use environment variables or a secrets manager.",
-                    consensus_score=1.0,
-                    agreeing_agents=["secret-scanner"],
-                    confidence=0.95,
-                )
-            )
 
     if findings:
         logger.info("Secret scanner found %d potential secret(s) in diff", len(findings))

--- a/tests/test_security_scanner.py
+++ b/tests/test_security_scanner.py
@@ -1,27 +1,9 @@
 """Tests for the security secret scanner."""
 
-import pytest
-
 from ai_reviewer.models.findings import Category, Severity
 from ai_reviewer.security.scanner import (
-    _shannon_entropy,
     scan_for_secrets,
 )
-
-
-class TestShannonEntropy:
-    def test_empty_string(self):
-        assert _shannon_entropy("") == 0.0
-
-    def test_single_char_repeated(self):
-        assert _shannon_entropy("aaaa") == 0.0
-
-    def test_two_equally_distributed_chars(self):
-        assert _shannon_entropy("ab") == pytest.approx(1.0)
-
-    def test_high_entropy_random_string(self):
-        entropy = _shannon_entropy("aB3$xZ9!qW7@mN5^")
-        assert entropy > 3.5
 
 
 class TestScanForSecretsPatterns:
@@ -97,34 +79,6 @@ class TestScanForSecretsPatterns:
         diff = self._make_diff("notify.py", 'SLACK = "xoxb-1234567890-abcdefghij"')
         findings = scan_for_secrets(diff)
         assert any("Slack" in f.title for f in findings)
-
-
-class TestScanForSecretsEntropy:
-    """High-entropy strings should be flagged."""
-
-    def _make_diff(self, added_line: str) -> str:
-        return (
-            "diff --git a/app.py b/app.py\n"
-            "--- a/app.py\n"
-            "+++ b/app.py\n"
-            "@@ -1,3 +1,4 @@\n"
-            " context\n"
-            f"+{added_line}\n"
-            " more context\n"
-        )
-
-    def test_high_entropy_string_detected(self):
-        high_entropy = "Kj8mNp2qRs4tUv6wXy0zA3bC"
-        diff = self._make_diff(f'TOKEN = "{high_entropy}"')
-        findings = scan_for_secrets(diff)
-        assert any("entropy" in f.title.lower() for f in findings)
-
-    def test_low_entropy_string_not_flagged(self):
-        low_entropy = "aaaaaaaaaaaaaaaaaaaa"
-        diff = self._make_diff(f'VALUE = "{low_entropy}"')
-        findings = scan_for_secrets(diff)
-        entropy_findings = [f for f in findings if "entropy" in f.title.lower()]
-        assert len(entropy_findings) == 0
 
 
 class TestScanOnlyAddedLines:
@@ -242,7 +196,7 @@ class TestScanMultipleFiles:
             "+++ b/b.py\n"
             "@@ -1,3 +1,4 @@\n"
             " context\n"
-            '+KEY2 = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh"\n'
+            '+KEY2 = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"\n'
             " more\n"
         )
         findings = scan_for_secrets(diff)


### PR DESCRIPTION
# feat: remove Shannon entropy secret detection

Entropy-based detection produced excessive false positives on public keys, test fixtures, and any long alphanumeric token that isn't actually a secret. The regex-based patterns (AWS, GitHub, Slack, etc.) are sufficient and precise.

Also fixes a pre-existing test bug where the GHP token in test_findings_across_files was 2 chars too short to match the regex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reduces secret detection coverage by removing the high-entropy heuristic, which may allow some non-patterned secrets to slip through, though it also lowers false positives. Changes are localized to the pre-LLM secret scanning and its tests.
> 
> **Overview**
> **Secret scanning is simplified to regex-only detection.** `scanner.py` removes the Shannon entropy/token heuristic (and related constants/imports) so findings are emitted only when a known `SECRET_PATTERNS` regex matches added lines.
> 
> **Tests are updated to match the new behavior.** Entropy unit tests are deleted and an existing multi-file test token is corrected to meet the GitHub PAT regex length.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e1ff89c065ce5e4088658d61fc1e3ac1fa1f0cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->