### PR TITLE
ci(doc-update): drop cache:pip so non-Python consumers don't fail

### DIFF
--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -58,10 +58,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # `cache: pip` deliberately not set here. setup-python's pip cache
+      # requires a requirements.txt / pyproject.toml in the *calling*
+      # repository to derive a cache key, and this workflow is meant to
+      # be called from non-Python repos (Rust, Go, JS, …) that have
+      # neither file. Setting it unconditionally caused calling repos
+      # to fail at this step with: "No file matched to
+      # [**/requirements.txt or **/pyproject.toml]". The single
+      # `pip install ai-code-reviewer` below is fast enough on a cold
+      # cache; reintroducing cache support would require a guard like
+      # `cache: ${{ hashFiles('**/requirements.txt', '**/pyproject.toml') != '' && 'pip' || '' }}`.
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: pip
 
       - name: Install ai-code-reviewer
         run: pip install ai-code-reviewer


### PR DESCRIPTION
## Summary

The `doc-update.yaml` reusable workflow sets `cache: pip` unconditionally on `actions/setup-python@v5`. The pip cache key is derived from a `requirements.txt` or `pyproject.toml` in the **calling** repository — but this workflow is documented as callable from any repo that wants AI doc updates on merge, including non-Python repos.

Calling repos that don't have either file (Rust, Go, JS, …) fail at the setup-python step with:

> `No file in /home/runner/work/<repo>/<repo> matched to [**/requirements.txt or **/pyproject.toml], make sure you have checked out the target repository`

## Real-world failure

`calimero-network/core` (Rust workspace) merged the consumer wiring in [calimero-network/core#2234](https://github.com/calimero-network/core/pull/2234), pinned to this repo's master at `71b0895c`. Every push to `core`'s master since then has failed at this step. Example run: https://github.com/calimero-network/core/actions/runs/25499553430

In the meantime they've inlined the workflow as a stop-gap (https://github.com/calimero-network/core/pull/2295). They'll revert to `uses:` once this lands and they bump their pinned SHA.

## Fix

Drop `cache: pip`. The single `pip install ai-code-reviewer` on a cold cache is cheap; the cache only saved a few seconds even when working.

If we want to support caching again later, a guarded form works for both worlds:

```yaml
cache: ${{ hashFiles('**/requirements.txt', '**/pyproject.toml') != '' && 'pip' || '' }}
```

I left that as a comment in the workflow rather than implementing it — the conditional adds complexity for marginal gain.

## Test plan

- [ ] Dogfooding push on this repo (which IS Python) confirms `setup-python` still succeeds without the cache
- [ ] After merge, `calimero-network/core` bumps its pinned SHA and reverts its inline workaround; their next master push successfully reaches the install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; it removes `setup-python` pip caching to avoid failures in non-Python caller repos, at the cost of slightly slower installs.
> 
> **Overview**
> Prevents the reusable `doc-update.yaml` workflow from failing when invoked by non-Python repositories by **dropping `actions/setup-python`’s `cache: pip` setting**.
> 
> Adds an inline comment explaining why caching is disabled and how it could be conditionally reintroduced later; the install step remains a direct `pip install ai-code-reviewer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6717e7208f0ca35b49ac4ab8be676e33e57e7aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->