### PR TITLE
feat: fix docs + helper scripts

### DIFF
--- a/scripts/test_docs_local.py
+++ b/scripts/test_docs_local.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Local smoke-test for the update-docs AI generation pipeline.
+
+Bypasses GitHub entirely — reads real local doc files, uses a fake diff,
+calls Claude directly via generate_doc_drafts, and prints the result.
+
+Usage:
+    ANTHROPIC_API_KEY=sk-ant-... python scripts/test_docs_local.py
+
+Optional env vars:
+    TARGET_FILE   — which doc file to test (default: README.md)
+    SOURCE_GLOB   — which source glob triggered it (default: src/ai_reviewer/cli.py)
+    DIFF_FILE     — path to a real .diff file to use instead of the fake one
+
+Does NOT need GITHUB_TOKEN.
+"""
+
+import asyncio
+import os
+import sys
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Run from repo root
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from ai_reviewer.config import AnthropicApiConfig
+from ai_reviewer.docs.analyzer import DocSuggestion, generate_doc_drafts
+
+FAKE_DIFF = textwrap.dedent("""\
+    diff --git a/src/ai_reviewer/cli.py b/src/ai_reviewer/cli.py
+    index abc1234..def5678 100644
+    --- a/src/ai_reviewer/cli.py
+    +++ b/src/ai_reviewer/cli.py
+    @@ -55,6 +55,15 @@ def cli(verbose: bool) -> None:
+     @cli.command("review-pr")
+    +@cli.command("update-docs")
+    +@click.argument("repo")
+    +@click.argument("pr_number", type=int)
+    +@click.option("--dry-run", is_flag=True)
+    +def update_docs_cmd(repo, pr_number, dry_run):
+    +    \"\"\"Generate and commit AI-drafted doc updates for a merged PR.\"\"\"
+    +    asyncio.run(_update_docs_async(repo=repo, pr_number=pr_number, dry_run=dry_run))
+    +
+""")
+
+
+def _make_gh_mock(target_file: str, current_content: str) -> MagicMock:
+    """Return a GitHub client mock that serves current_content for target_file."""
+    gh = MagicMock()
+
+    file_mock = MagicMock()
+    file_mock.decoded_content = current_content.encode()
+
+    def get_file_contents(repo_name, path, ref):
+        if path == target_file:
+            return file_mock
+        raise Exception(f"404: {path} not found")
+
+    gh.get_file_contents.side_effect = get_file_contents
+    return gh
+
+
+async def main() -> None:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("ERROR: ANTHROPIC_API_KEY not set", file=sys.stderr)
+        sys.exit(1)
+
+    target_file = os.environ.get("TARGET_FILE", "README.md")
+    source_glob = os.environ.get("SOURCE_GLOB", "src/ai_reviewer/cli.py")
+
+    # Read real current content from local filesystem
+    local_path = REPO_ROOT / target_file
+    if not local_path.exists():
+        print(f"ERROR: {local_path} does not exist", file=sys.stderr)
+        sys.exit(1)
+    current_content = local_path.read_text()
+
+    # Use provided diff or fallback to fake one
+    diff_file = os.environ.get("DIFF_FILE")
+    diff = Path(diff_file).read_text() if diff_file else FAKE_DIFF
+
+    print(f"Target file : {target_file} ({len(current_content)} chars)")
+    print(f"Source glob : {source_glob}")
+    print(f"Diff size   : {len(diff)} chars")
+    print()
+
+    suggestion = DocSuggestion(
+        file=target_file,
+        reason=(
+            f"Files matching `{source_glob}` were changed but `{target_file}` "
+            "was not updated (per source_to_docs_mapping)."
+        ),
+    )
+
+    anthropic_cfg = AnthropicApiConfig(api_key=api_key)
+    gh = _make_gh_mock(target_file, current_content)
+
+    print("Calling Claude to generate doc draft...")
+    drafts = await generate_doc_drafts(
+        suggestions=[suggestion],
+        diff=diff,
+        repo_name="calimero-network/ai-code-reviewer",
+        ref="HEAD",
+        anthropic_cfg=anthropic_cfg,
+        gh=gh,
+    )
+
+    if not drafts:
+        print("\nResult: Claude says NO_UPDATE_NEEDED — file is already accurate.")
+        return
+
+    draft = drafts[0]
+    if draft.error:
+        print(f"\nResult: ERROR — {draft.error}")
+        sys.exit(1)
+
+    lines = draft.updated_content.splitlines()
+    original_lines = current_content.splitlines()
+    print(f"\nResult: Claude generated an update ({len(lines)} lines vs {len(original_lines)} original)")
+    print()
+
+    # Show a diff-like summary of changed lines
+    import difflib
+    diff_output = list(difflib.unified_diff(
+        original_lines,
+        lines,
+        fromfile=f"original/{target_file}",
+        tofile=f"updated/{target_file}",
+        lineterm="",
+        n=3,
+    ))
+    if diff_output:
+        print("\n".join(diff_output[:80]))
+        if len(diff_output) > 80:
+            print(f"... ({len(diff_output) - 80} more diff lines)")
+    else:
+        print("(No textual differences — content identical)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/test_docs_local.py
+++ b/scripts/test_docs_local.py
@@ -11,11 +11,13 @@ Optional env vars:
     TARGET_FILE   — which doc file to test (default: README.md)
     SOURCE_GLOB   — which source glob triggered it (default: src/ai_reviewer/cli.py)
     DIFF_FILE     — path to a real .diff file to use instead of the fake one
+    REPO_NAME     — repo slug passed to generate_doc_drafts (default: calimero-network/ai-code-reviewer)
 
 Does NOT need GITHUB_TOKEN.
 """
 
 import asyncio
+import difflib
 import os
 import sys
 import textwrap
@@ -71,9 +73,14 @@ async def main() -> None:
 
     target_file = os.environ.get("TARGET_FILE", "README.md")
     source_glob = os.environ.get("SOURCE_GLOB", "src/ai_reviewer/cli.py")
+    repo_name = os.environ.get("REPO_NAME", "calimero-network/ai-code-reviewer")
 
-    # Read real current content from local filesystem
-    local_path = REPO_ROOT / target_file
+    # Resolve and validate TARGET_FILE stays within the repo root
+    repo_root_resolved = REPO_ROOT.resolve()
+    local_path = (REPO_ROOT / target_file).resolve()
+    if not local_path.is_relative_to(repo_root_resolved):
+        print(f"ERROR: TARGET_FILE {target_file!r} resolves outside repo root", file=sys.stderr)
+        sys.exit(1)
     if not local_path.exists():
         print(f"ERROR: {local_path} does not exist", file=sys.stderr)
         sys.exit(1)
@@ -81,7 +88,14 @@ async def main() -> None:
 
     # Use provided diff or fallback to fake one
     diff_file = os.environ.get("DIFF_FILE")
-    diff = Path(diff_file).read_text() if diff_file else FAKE_DIFF
+    if diff_file:
+        diff_path = Path(diff_file).resolve()
+        if not diff_path.is_relative_to(repo_root_resolved):
+            print(f"ERROR: DIFF_FILE {diff_file!r} resolves outside repo root", file=sys.stderr)
+            sys.exit(1)
+        diff = diff_path.read_text()
+    else:
+        diff = FAKE_DIFF
 
     print(f"Target file : {target_file} ({len(current_content)} chars)")
     print(f"Source glob : {source_glob}")
@@ -103,7 +117,7 @@ async def main() -> None:
     drafts = await generate_doc_drafts(
         suggestions=[suggestion],
         diff=diff,
-        repo_name="calimero-network/ai-code-reviewer",
+        repo_name=repo_name,
         ref="HEAD",
         anthropic_cfg=anthropic_cfg,
         gh=gh,
@@ -124,9 +138,6 @@ async def main() -> None:
         f"\nResult: Claude generated an update ({len(lines)} lines vs {len(original_lines)} original)"
     )
     print()
-
-    # Show a diff-like summary of changed lines
-    import difflib
 
     diff_output = list(
         difflib.unified_diff(

--- a/scripts/test_docs_local.py
+++ b/scripts/test_docs_local.py
@@ -26,8 +26,8 @@ from unittest.mock import MagicMock
 REPO_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
-from ai_reviewer.config import AnthropicApiConfig
-from ai_reviewer.docs.analyzer import DocSuggestion, generate_doc_drafts
+from ai_reviewer.config import AnthropicApiConfig  # noqa: E402
+from ai_reviewer.docs.analyzer import DocSuggestion, generate_doc_drafts  # noqa: E402
 
 FAKE_DIFF = textwrap.dedent("""\
     diff --git a/src/ai_reviewer/cli.py b/src/ai_reviewer/cli.py
@@ -54,7 +54,7 @@ def _make_gh_mock(target_file: str, current_content: str) -> MagicMock:
     file_mock = MagicMock()
     file_mock.decoded_content = current_content.encode()
 
-    def get_file_contents(repo_name, path, ref):
+    def get_file_contents(_repo_name, path, _ref):
         if path == target_file:
             return file_mock
         raise Exception(f"404: {path} not found")

--- a/scripts/test_docs_local.py
+++ b/scripts/test_docs_local.py
@@ -120,19 +120,24 @@ async def main() -> None:
 
     lines = draft.updated_content.splitlines()
     original_lines = current_content.splitlines()
-    print(f"\nResult: Claude generated an update ({len(lines)} lines vs {len(original_lines)} original)")
+    print(
+        f"\nResult: Claude generated an update ({len(lines)} lines vs {len(original_lines)} original)"
+    )
     print()
 
     # Show a diff-like summary of changed lines
     import difflib
-    diff_output = list(difflib.unified_diff(
-        original_lines,
-        lines,
-        fromfile=f"original/{target_file}",
-        tofile=f"updated/{target_file}",
-        lineterm="",
-        n=3,
-    ))
+
+    diff_output = list(
+        difflib.unified_diff(
+            original_lines,
+            lines,
+            fromfile=f"original/{target_file}",
+            tofile=f"updated/{target_file}",
+            lineterm="",
+            n=3,
+        )
+    )
     if diff_output:
         print("\n".join(diff_output[:80]))
         if len(diff_output) > 80:

--- a/src/ai_reviewer/docs/analyzer.py
+++ b/src/ai_reviewer/docs/analyzer.py
@@ -407,11 +407,17 @@ def _is_no_update_response(content: str) -> bool:
     return False
 
 
+def _normalize_lines(text: str) -> str:
+    """Normalize line endings and strip trailing whitespace per line."""
+    return "\n".join(l.rstrip() for l in text.replace("\r\n", "\n").split("\n"))
+
+
 def _apply_html_patches(original: str, response: str) -> str | None:
     """Apply FIND/REPLACE patch blocks from the model response to the original HTML.
 
-    Returns the patched content, or None if no valid patches were found or a
-    FIND block does not match anywhere in the document.
+    Tries exact match first, then falls back to line-normalized match to handle
+    minor whitespace differences in what the model copied from the source.
+    Returns None if no valid patch blocks were found or any FIND doesn't match.
     """
     find_blocks = _re.findall(r"<<<FIND\n(.*?)\nFIND>>>", response, _re.DOTALL)
     replace_blocks = _re.findall(r"<<<REPLACE\n(.*?)\nREPLACE>>>", response, _re.DOTALL)
@@ -421,9 +427,16 @@ def _apply_html_patches(original: str, response: str) -> str | None:
 
     result = original
     for find, replace in zip(find_blocks, replace_blocks):
-        if find not in result:
+        if find in result:
+            result = result.replace(find, replace, 1)
+            continue
+        # Fallback: normalize trailing whitespace on each line and retry
+        norm_original = _normalize_lines(result)
+        norm_find = _normalize_lines(find)
+        if norm_find not in norm_original:
             return None
-        result = result.replace(find, replace, 1)
+        idx = norm_original.find(norm_find)
+        result = result[:idx] + replace + result[idx + len(norm_find):]
 
     return result
 

--- a/src/ai_reviewer/docs/analyzer.py
+++ b/src/ai_reviewer/docs/analyzer.py
@@ -422,7 +422,6 @@ def _apply_html_patches(original: str, response: str) -> str | None:
     result = original
     for find, replace in zip(find_blocks, replace_blocks):
         if find not in result:
-            logger.warning("HTML patch FIND text not found in document: %r", find[:80])
             return None
         result = result.replace(find, replace, 1)
 

--- a/src/ai_reviewer/docs/analyzer.py
+++ b/src/ai_reviewer/docs/analyzer.py
@@ -405,28 +405,29 @@ def _is_no_update_response(content: str) -> bool:
     return False
 
 
-def _looks_like_html(content: str) -> bool:
-    """Cheap sanity check that ``content`` resembles an HTML document.
+def _extract_html(content: str) -> str | None:
+    """Strip any preamble the model prepended before the HTML document.
 
-    Used as a last line of defense before overwriting an HTML file: if the
-    model returned plain prose instead of markup, the response should be
-    treated as a failed draft rather than written to disk. Looks for either
-    a doctype/root tag at the start, or simply the presence of any tag-like
-    construct in the body — deliberately permissive so partial pages still
-    pass while obvious failures (no ``<`` anywhere) are caught.
+    The system prompt says to start with ``<!DOCTYPE`` or ``<html``, but models
+    occasionally output reasoning text first. Find the first occurrence of
+    either tag (case-insensitive) and return everything from there onward.
+    Returns ``None`` if no HTML root tag is found at all.
     """
-    head = content.lstrip().lower()[:64]
-    if head.startswith(("<!doctype", "<html", "<?xml")):
-        return True
-    return "<" in content and ">" in content
+    lower = content.lower()
+    for marker in ("<!doctype", "<html"):
+        idx = lower.find(marker)
+        if idx != -1:
+            return content[idx:]
+    return None
 
 
 # ~4K chars ≈ ~1K tokens — keeps prompt cost low while providing enough context.
 _MAX_DIFF_CHARS = 4000
 # ~8K chars ≈ ~2K tokens — sufficient for most Markdown docs.
 _MAX_DOC_CHARS = 8000
-# HTML docs are larger due to markup; allow more context for accurate updates.
-_MAX_DOC_CHARS_HTML = 20_000
+# HTML docs can be large — pass the full file so the model doesn't regenerate
+# a truncated version and drop sections it never saw.
+_MAX_DOC_CHARS_HTML = 100_000
 
 
 def _strip_html_tags(html: str) -> str:
@@ -521,16 +522,15 @@ async def generate_doc_drafts(
                     content = result.strip()
                     if is_html and _is_no_update_response(content):
                         return None  # model says no update needed
-                    if is_html and not _looks_like_html(content):
-                        # Defense in depth: model returned prose instead of
-                        # HTML (e.g. forgot the sentinel and explained why no
-                        # update was needed). Treat as a failed draft so the
-                        # file is not overwritten.
-                        return DocDraft(
-                            suggestion=suggestion,
-                            updated_content="",
-                            error="model returned non-HTML content for an HTML target",
-                        )
+                    if is_html:
+                        extracted = _extract_html(content)
+                        if extracted is None:
+                            return DocDraft(
+                                suggestion=suggestion,
+                                updated_content="",
+                                error="model returned non-HTML content for an HTML target",
+                            )
+                        content = extracted
                     return DocDraft(suggestion=suggestion, updated_content=content)
                 except Exception as exc:
                     return DocDraft(suggestion=suggestion, updated_content="", error=str(exc))

--- a/src/ai_reviewer/docs/analyzer.py
+++ b/src/ai_reviewer/docs/analyzer.py
@@ -409,7 +409,7 @@ def _is_no_update_response(content: str) -> bool:
 
 def _normalize_lines(text: str) -> str:
     """Normalize line endings and strip trailing whitespace per line."""
-    return "\n".join(l.rstrip() for l in text.replace("\r\n", "\n").split("\n"))
+    return "\n".join(line.rstrip() for line in text.replace("\r\n", "\n").split("\n"))
 
 
 def _apply_html_patches(original: str, response: str) -> str | None:
@@ -426,7 +426,7 @@ def _apply_html_patches(original: str, response: str) -> str | None:
         return None
 
     result = original
-    for find, replace in zip(find_blocks, replace_blocks):
+    for find, replace in zip(find_blocks, replace_blocks, strict=False):
         if find in result:
             result = result.replace(find, replace, 1)
             continue

--- a/src/ai_reviewer/docs/analyzer.py
+++ b/src/ai_reviewer/docs/analyzer.py
@@ -352,23 +352,25 @@ Rules:
 """
 
 _DOC_DRAFT_SYSTEM_HTML = """\
-You are a technical writer updating a static HTML documentation page after a code change.
-Given the current HTML file and a code diff, decide whether the page needs updating.
+You are a technical writer making targeted updates to an HTML documentation page after a code change.
 
-If NO update is needed, your ENTIRE response must be exactly the token below
-on a single line, with no preamble, no explanation, no markdown fences, and
-no trailing commentary:
-NO_UPDATE_NEEDED
+Do NOT return the full file. Output ONLY the specific text that needs changing, using FIND/REPLACE blocks.
 
-If an update IS needed, return the COMPLETE updated HTML file. The response
-must begin with `<!DOCTYPE` or `<html` and contain the full document.
+Format for each change:
+<<<FIND
+exact text to replace (copy verbatim from the source, including tags and whitespace)
+FIND>>>
+<<<REPLACE
+replacement text
+REPLACE>>>
 
-Rules for HTML updates:
-- Preserve ALL HTML structure, tags, attributes, CSS classes, inline styles, and scripts exactly.
-- Only update human-readable text content that is made inaccurate by the code change.
-- Do not reformat, re-indent, or restructure the HTML.
-- Do not escape or unescape entities that were already correct.
-- Do not add commentary before or after the HTML — return only the file or NO_UPDATE_NEEDED.
+Rules:
+- FIND text must match the source HTML exactly, character for character.
+- Include enough surrounding lines in FIND to make it unique in the document.
+- To insert new content, include the anchor line in FIND and repeat it in REPLACE with the addition.
+- Multiple blocks are fine for multiple changes.
+- Only change text made inaccurate by the code diff — leave everything else untouched.
+- If no changes are needed, output exactly: NO_UPDATE_NEEDED
 """
 
 # Sentinel returned by Claude when an HTML page does not need updating.
@@ -405,20 +407,26 @@ def _is_no_update_response(content: str) -> bool:
     return False
 
 
-def _extract_html(content: str) -> str | None:
-    """Strip any preamble the model prepended before the HTML document.
+def _apply_html_patches(original: str, response: str) -> str | None:
+    """Apply FIND/REPLACE patch blocks from the model response to the original HTML.
 
-    The system prompt says to start with ``<!DOCTYPE`` or ``<html``, but models
-    occasionally output reasoning text first. Find the first occurrence of
-    either tag (case-insensitive) and return everything from there onward.
-    Returns ``None`` if no HTML root tag is found at all.
+    Returns the patched content, or None if no valid patches were found or a
+    FIND block does not match anywhere in the document.
     """
-    lower = content.lower()
-    for marker in ("<!doctype", "<html"):
-        idx = lower.find(marker)
-        if idx != -1:
-            return content[idx:]
-    return None
+    find_blocks = _re.findall(r"<<<FIND\n(.*?)\nFIND>>>", response, _re.DOTALL)
+    replace_blocks = _re.findall(r"<<<REPLACE\n(.*?)\nREPLACE>>>", response, _re.DOTALL)
+
+    if not find_blocks or len(find_blocks) != len(replace_blocks):
+        return None
+
+    result = original
+    for find, replace in zip(find_blocks, replace_blocks):
+        if find not in result:
+            logger.warning("HTML patch FIND text not found in document: %r", find[:80])
+            return None
+        result = result.replace(find, replace, 1)
+
+    return result
 
 
 # ~4K chars ≈ ~1K tokens — keeps prompt cost low while providing enough context.
@@ -494,14 +502,12 @@ async def generate_doc_drafts(
                 )
 
                 if is_html:
-                    plain_text = _strip_html_tags(current_content)[:2000]
                     user_prompt = (
                         f"## HTML File: {suggestion.file}\n\n"
-                        f"### Raw HTML\n\n{truncated_doc}\n\n"
-                        f"### Plain-text content (for relevance check)\n\n{plain_text}\n\n"
+                        f"{truncated_doc}\n\n"
                         f"## Code Diff\n\n{truncated_diff}\n\n"
                         f"## Why This File May Need Updating\n\n{suggestion.reason}\n\n"
-                        "Return NO_UPDATE_NEEDED if unchanged, or the complete updated HTML file."
+                        "Output FIND/REPLACE patches for needed changes, or NO_UPDATE_NEEDED."
                     )
                 else:
                     user_prompt = (
@@ -520,17 +526,17 @@ async def generate_doc_drafts(
                         max_tokens=8192,
                     )
                     content = result.strip()
-                    if is_html and _is_no_update_response(content):
+                    if _is_no_update_response(content):
                         return None  # model says no update needed
                     if is_html:
-                        extracted = _extract_html(content)
-                        if extracted is None:
+                        patched = _apply_html_patches(current_content, content)
+                        if patched is None:
                             return DocDraft(
                                 suggestion=suggestion,
                                 updated_content="",
-                                error="model returned non-HTML content for an HTML target",
+                                error="could not apply HTML patches (FIND text not found or malformed response)",
                             )
-                        content = extracted
+                        content = patched
                     return DocDraft(suggestion=suggestion, updated_content=content)
                 except Exception as exc:
                     return DocDraft(suggestion=suggestion, updated_content="", error=str(exc))

--- a/src/ai_reviewer/docs/analyzer.py
+++ b/src/ai_reviewer/docs/analyzer.py
@@ -436,7 +436,7 @@ def _apply_html_patches(original: str, response: str) -> str | None:
         if norm_find not in norm_original:
             return None
         idx = norm_original.find(norm_find)
-        result = result[:idx] + replace + result[idx + len(norm_find):]
+        result = result[:idx] + replace + result[idx + len(norm_find) :]
 
     return result
 

--- a/src/ai_reviewer/docs/analyzer.py
+++ b/src/ai_reviewer/docs/analyzer.py
@@ -436,7 +436,7 @@ def _apply_html_patches(original: str, response: str) -> str | None:
         if norm_find not in norm_original:
             return None
         idx = norm_original.find(norm_find)
-        result = result[:idx] + replace + result[idx + len(norm_find) :]
+        result = norm_original[:idx] + replace + norm_original[idx + len(norm_find) :]
 
     return result
 

--- a/src/ai_reviewer/docs/analyzer.py
+++ b/src/ai_reviewer/docs/analyzer.py
@@ -538,7 +538,7 @@ async def generate_doc_drafts(
                         max_tokens=8192,
                     )
                     content = result.strip()
-                    if _is_no_update_response(content):
+                    if is_html and _is_no_update_response(content):
                         return None  # model says no update needed
                     if is_html:
                         patched = _apply_html_patches(current_content, content)

--- a/src/ai_reviewer/docs/updater.py
+++ b/src/ai_reviewer/docs/updater.py
@@ -60,7 +60,7 @@ async def run_doc_update(
     ``result.successful`` contains the generated drafts for the caller to
     display.
     """
-    from ai_reviewer.docs.analyzer import DocAnalyzer, DocSuggestion, generate_doc_drafts
+    from ai_reviewer.docs.analyzer import DocAnalyzer, DocSuggestion, generate_doc_drafts, is_architecture_impacting
 
     pr = gh.get_pull_request(repo, pr_number)
     base_branch = base or pr.base.ref
@@ -121,7 +121,9 @@ async def run_doc_update(
         if _doc_static is not None
         else doc_generation.static_docs_dirs
     )
-    if effective_static_dirs:
+    if effective_static_dirs and is_architecture_impacting(
+        changed_paths, changed_paths_with_status
+    ):
         already_covered = {s.file for s in mapping_suggestions}
         html_paths = gh.get_html_files_in_dirs(repo, ref, effective_static_dirs)
         for html_path in html_paths:
@@ -131,7 +133,7 @@ async def run_doc_update(
                         file=html_path,
                         reason=(
                             f"Static HTML page in `{html_path}` — scanning for updates "
-                            "triggered by code changes in this PR."
+                            "triggered by architecture-impacting changes in this PR."
                         ),
                     )
                 )
@@ -154,6 +156,8 @@ async def run_doc_update(
 
     successful = [d for d in drafts if d.updated_content and not d.error]
     failed = [d for d in drafts if d.error]
+    for d in failed:
+        logger.warning("Doc draft failed for %s: %s", d.suggestion.file, d.error)
 
     if not successful:
         return DocUpdateResult(

--- a/src/ai_reviewer/docs/updater.py
+++ b/src/ai_reviewer/docs/updater.py
@@ -179,5 +179,6 @@ async def run_doc_update(
         assignee=pr.user.login if pr.user else None,
         labels=effective_pr_labels,
         draft=effective_pr_draft,
+        pr_number=pr_number,
     )
     return DocUpdateResult(successful=successful, failed=failed, pr_url=pr_url)

--- a/src/ai_reviewer/docs/updater.py
+++ b/src/ai_reviewer/docs/updater.py
@@ -60,7 +60,12 @@ async def run_doc_update(
     ``result.successful`` contains the generated drafts for the caller to
     display.
     """
-    from ai_reviewer.docs.analyzer import DocAnalyzer, DocSuggestion, generate_doc_drafts, is_architecture_impacting
+    from ai_reviewer.docs.analyzer import (  # noqa: E501
+        DocAnalyzer,
+        DocSuggestion,
+        generate_doc_drafts,
+        is_architecture_impacting,
+    )
 
     pr = gh.get_pull_request(repo, pr_number)
     base_branch = base or pr.base.ref

--- a/src/ai_reviewer/github/client.py
+++ b/src/ai_reviewer/github/client.py
@@ -13,7 +13,7 @@ import time
 from collections import OrderedDict, defaultdict
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import requests
 import yaml
@@ -1200,7 +1200,7 @@ class GitHubClient:
             "Content-Type": "application/json",
         }
 
-        payload: dict[str, object] = {"query": query}
+        payload: dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = variables
 

--- a/src/ai_reviewer/github/client.py
+++ b/src/ai_reviewer/github/client.py
@@ -1579,6 +1579,7 @@ class GitHubClient:
         assignee: str | None = None,
         labels: list[str] | None = None,
         draft: bool = True,
+        pr_number: int | None = None,
     ) -> str:
         """Create a branch, commit updated doc files, and open a PR.
 
@@ -1587,15 +1588,23 @@ class GitHubClient:
 
         Returns the HTML URL of the newly opened PR.
         """
-        branch_name = f"docs/auto-{base_sha[:7]}"
+        suffix = f"pr{pr_number}-{base_sha[:7]}" if pr_number else base_sha[:7]
+        branch_name = f"docs/auto-{suffix}"
         repo = self._gh.get_repo(repo_name)
 
-        # Create branch off the base SHA
+        # Create branch off the base SHA; if it already exists reset it so
+        # re-runs start from a clean slate with no leftover commits.
+        ref_path = f"refs/heads/{branch_name}"
         try:
-            repo.create_git_ref(ref=f"refs/heads/{branch_name}", sha=base_sha)
+            repo.create_git_ref(ref=ref_path, sha=base_sha)
         except Exception as e:
             _raise_if_forbidden(e)
-            raise RuntimeError(f"Could not create branch {branch_name}: {e}") from e
+            try:
+                existing_ref = repo.get_git_ref(f"heads/{branch_name}")
+                existing_ref.edit(sha=base_sha, force=True)
+                logger.info("Reset existing branch %s to %s", branch_name, base_sha[:7])
+            except Exception as e2:
+                raise RuntimeError(f"Could not create or reset branch {branch_name}: {e2}") from e2
 
         # Commit each updated file onto the new branch
         committed: list[str] = []

--- a/tests/test_doc_analyzer.py
+++ b/tests/test_doc_analyzer.py
@@ -759,35 +759,49 @@ class TestIsNoUpdateResponse:
         assert not _is_no_update_response("")
 
 
-class TestLooksLikeHtml:
-    """Tests for _looks_like_html — last-line-of-defense sanity check."""
+class TestApplyHtmlPatches:
+    """Tests for _apply_html_patches — surgical FIND/REPLACE on HTML files."""
 
-    def test_doctype(self):
-        from ai_reviewer.docs.analyzer import _looks_like_html
+    def test_basic_replacement(self):
+        from ai_reviewer.docs.analyzer import _apply_html_patches
 
-        assert _looks_like_html("<!DOCTYPE html>\n<html></html>")
-
-    def test_html_tag(self):
-        from ai_reviewer.docs.analyzer import _looks_like_html
-
-        assert _looks_like_html("<html><body>x</body></html>")
-
-    def test_partial_markup_accepted(self):
-        from ai_reviewer.docs.analyzer import _looks_like_html
-
-        assert _looks_like_html("<div>partial</div>")
-
-    def test_plain_prose_rejected(self):
-        from ai_reviewer.docs.analyzer import _looks_like_html
-
-        assert not _looks_like_html(
-            "The code diff modifies a workflow file; no doc updates are needed."
+        original = "<div>old value</div>"
+        response = (
+            "<<<FIND\n<div>old value</div>\nFIND>>>\n<<<REPLACE\n<div>new value</div>\nREPLACE>>>"
         )
+        assert _apply_html_patches(original, response) == "<div>new value</div>"
 
-    def test_empty_rejected(self):
-        from ai_reviewer.docs.analyzer import _looks_like_html
+    def test_multiple_patches(self):
+        from ai_reviewer.docs.analyzer import _apply_html_patches
 
-        assert not _looks_like_html("")
+        original = "<a>foo</a><b>bar</b>"
+        response = (
+            "<<<FIND\n<a>foo</a>\nFIND>>>\n<<<REPLACE\n<a>FOO</a>\nREPLACE>>>\n"
+            "<<<FIND\n<b>bar</b>\nFIND>>>\n<<<REPLACE\n<b>BAR</b>\nREPLACE>>>"
+        )
+        assert _apply_html_patches(original, response) == "<a>FOO</a><b>BAR</b>"
+
+    def test_find_not_found_returns_none(self):
+        from ai_reviewer.docs.analyzer import _apply_html_patches
+
+        original = "<div>actual content</div>"
+        response = (
+            "<<<FIND\n<div>different content</div>\nFIND>>>\n<<<REPLACE\n<div>x</div>\nREPLACE>>>"
+        )
+        assert _apply_html_patches(original, response) is None
+
+    def test_malformed_no_blocks_returns_none(self):
+        from ai_reviewer.docs.analyzer import _apply_html_patches
+
+        assert _apply_html_patches("<html>x</html>", "plain prose response") is None
+
+    def test_whitespace_normalized_fallback(self):
+        from ai_reviewer.docs.analyzer import _apply_html_patches
+
+        original = "<div>  value  </div>"
+        # FIND has trailing spaces stripped — normalized match should still work
+        response = "<<<FIND\n<div>  value\nFIND>>>\n<<<REPLACE\n<div>new\nREPLACE>>>"
+        assert _apply_html_patches(original, response) is not None
 
 
 class TestGenerateDocDraftsHtmlSentinel:
@@ -874,11 +888,11 @@ class TestGenerateDocDraftsHtmlSentinel:
         assert len(drafts) == 1
         assert drafts[0].updated_content == ""
         assert drafts[0].error is not None
-        assert "non-HTML" in drafts[0].error
+        assert "could not apply HTML patches" in drafts[0].error
 
     @pytest.mark.asyncio
     async def test_html_real_update_passes_through(self):
-        """A genuine updated HTML response is preserved unchanged."""
+        """A genuine FIND/REPLACE patch response is applied correctly."""
         from unittest.mock import AsyncMock, MagicMock, patch
 
         from ai_reviewer.config import AnthropicApiConfig
@@ -891,11 +905,14 @@ class TestGenerateDocDraftsHtmlSentinel:
         mock_gh = MagicMock()
         mock_gh.get_file_contents.return_value = mock_file_content
 
-        new_html = "<!DOCTYPE html>\n<html>new</html>"
+        patch_response = (
+            "<<<FIND\n<html>old</html>\nFIND>>>\n<<<REPLACE\n<html>new</html>\nREPLACE>>>"
+        )
+        expected_html = "<!DOCTYPE html>\n<html>new</html>"
 
         with patch("ai_reviewer.agents.anthropic_client.AnthropicClient") as MockClient:
             mock_instance = AsyncMock()
-            mock_instance.run_completion = AsyncMock(return_value=new_html)
+            mock_instance.run_completion = AsyncMock(return_value=patch_response)
             MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_instance)
             MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -910,7 +927,7 @@ class TestGenerateDocDraftsHtmlSentinel:
             )
 
         assert len(drafts) == 1
-        assert drafts[0].updated_content == new_html
+        assert drafts[0].updated_content == expected_html
         assert drafts[0].error is None
 
     @pytest.mark.asyncio


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how AI-generated HTML updates are produced/applied and alters doc-update PR branch creation/reset behavior, which could lead to failed patch application or unexpected overwrites if edge cases slip through.
> 
> **Overview**
> **HTML doc updating is now patch-based.** The HTML system prompt is rewritten to request `<<<FIND`/`<<<REPLACE>>>` blocks, and `generate_doc_drafts` now applies those patches to the existing HTML via a new `_apply_html_patches` helper (with whitespace-normalized fallback) instead of trusting full-file HTML output.
> 
> **Doc-update orchestration is tightened and hardened.** Static HTML pages are only scanned when changes are architecture-impacting, draft failures are logged, and `create_doc_update_pr` now uses a `pr_number`-scoped branch name and force-resets an existing branch to the base SHA to make re-runs idempotent.
> 
> **Tooling/tests updated.** Adds `scripts/test_docs_local.py` for local end-to-end smoke testing of doc generation, updates unit tests for the new HTML patch application behavior, and adjusts a GraphQL payload type to `Any`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b203c151a07d5e51a30166cf147b7ffc0403fcee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->