### PR TITLE
fix(ci): install from source instead of stale PyPI package

### DIFF
--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -73,10 +73,11 @@ jobs:
           python-version: "3.11"
 
       - name: Install ai-code-reviewer
-        env:
-          REPO: ${{ github.repository }}
         run: |
-          if [ "$REPO" = "calimero-network/ai-code-reviewer" ]; then
+          # Install from local checkout when running inside this repo or any fork of it.
+          # git SHAs are content-addressed, so @<full-SHA> is already tamper-evident
+          # without needing --require-hashes (which is not supported for git+ installs).
+          if grep -q 'name = "ai-code-reviewer"' pyproject.toml 2>/dev/null; then
             pip install .
           else
             pip install git+https://github.com/calimero-network/ai-code-reviewer.git@78514fe2453d3a1e95ba9b9bd6e16dc53095046b

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -73,11 +73,13 @@ jobs:
           python-version: "3.11"
 
       - name: Install ai-code-reviewer
+        env:
+          REPO: ${{ github.repository }}
         run: |
-          if [ "${{ github.repository }}" = "calimero-network/ai-code-reviewer" ]; then
+          if [ "$REPO" = "calimero-network/ai-code-reviewer" ]; then
             pip install .
           else
-            pip install git+https://github.com/calimero-network/ai-code-reviewer.git
+            pip install git+https://github.com/calimero-network/ai-code-reviewer.git@v0.1.0
           fi
 
       - name: Get merged PR number

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -73,7 +73,12 @@ jobs:
           python-version: "3.11"
 
       - name: Install ai-code-reviewer
-        run: pip install ai-code-reviewer
+        run: |
+          if [ "${{ github.repository }}" = "calimero-network/ai-code-reviewer" ]; then
+            pip install .
+          else
+            pip install git+https://github.com/calimero-network/ai-code-reviewer.git
+          fi
 
       - name: Get merged PR number
         id: pr

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -79,7 +79,7 @@ jobs:
           if [ "$REPO" = "calimero-network/ai-code-reviewer" ]; then
             pip install .
           else
-            pip install git+https://github.com/calimero-network/ai-code-reviewer.git@v0.1.0
+            pip install git+https://github.com/calimero-network/ai-code-reviewer.git@78514fe2453d3a1e95ba9b9bd6e16dc53095046b
           fi
 
       - name: Get merged PR number


### PR DESCRIPTION
## Summary

- `update-docs` was added in v0.1.0 but the latest PyPI release is v0.0.23
- CI was running `pip install ai-code-reviewer` which installed the old package without the `update-docs` subcommand → `ai-reviewer: command not found`
- When dogfooding (this repo): install from local checkout with `pip install .`
- When used as a reusable workflow from external repos: install from GitHub source

## Test plan

- [ ] `update-docs` job in `doc-update.yaml` completes without `command not found`
- [ ] External callers install the correct version from GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the GitHub Actions workflow install step, but could break `doc-update` runs if the repo-detection check or pinned git SHA becomes invalid.
> 
> **Overview**
> Fixes the reusable `doc-update` workflow to avoid installing a stale PyPI release by **installing `ai-code-reviewer` from source**.
> 
> When running within this repo (or forks), it installs from the checked-out workspace via `pip install .`; otherwise it installs from a **pinned GitHub commit SHA** via `git+https` to ensure external callers get the correct version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713c5b1251132dd93b6ec70889e336dad3c09402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->