### PR TITLE
fix(docs): recurse into sub-directories when scanning HTML doc pages

### DIFF
--- a/src/ai_reviewer/github/client.py
+++ b/src/ai_reviewer/github/client.py
@@ -1482,27 +1482,38 @@ class GitHubClient:
         return resolved_ids
 
     def get_html_files_in_dirs(self, repo_name: str, ref: str, dirs: list[str]) -> list[str]:
-        """Return paths of all .html files found directly inside the given directories.
+        """Return paths of all .html files found under the given directories.
 
-        Does not recurse into sub-directories — flat docs-site layouts are assumed.
-        404s are swallowed; 403s are re-raised.
+        Recurses into sub-directories so nested docs-site layouts (e.g.
+        ``architecture/crates/node.html``) are covered, not just the top level.
+        Each directory is walked with ``get_contents``, which costs one API call
+        per (sub)directory — bounded because the walk is scoped to the doc dirs
+        passed in, never the whole repo.  404s are swallowed; 403s are re-raised.
+
+        Returns a sorted, de-duplicated list so overlapping *dirs* don't yield
+        the same page twice and the order is stable.
         """
         repo = self._gh.get_repo(repo_name)
-        found: list[str] = []
+        found: set[str] = set()
         for dir_path in dirs:
-            lookup = dir_path.rstrip("/")
-            try:
-                contents = repo.get_contents(lookup, ref=ref)
+            # DFS over the directory subtree; only push dirs we discover.
+            stack: list[str] = [dir_path.rstrip("/")]
+            while stack:
+                lookup = stack.pop()
+                try:
+                    contents = repo.get_contents(lookup, ref=ref)
+                except Exception as e:
+                    _raise_if_forbidden(e)
+                    logger.debug("get_html_files_in_dirs: %s not found at %s: %s", lookup, ref, e)
+                    continue
                 items = contents if isinstance(contents, list) else [contents]
                 for item in items:
-                    if getattr(item, "type", None) == "file" and item.path.lower().endswith(
-                        ".html"
-                    ):
-                        found.append(item.path)
-            except Exception as e:
-                _raise_if_forbidden(e)
-                logger.debug("get_html_files_in_dirs: %s not found at %s: %s", dir_path, ref, e)
-        return found
+                    item_type = getattr(item, "type", None)
+                    if item_type == "dir":
+                        stack.append(item.path)
+                    elif item_type == "file" and item.path.lower().endswith(".html"):
+                        found.add(item.path)
+        return sorted(found)
 
     def has_open_doc_update_pr(self, repo_name: str, base_branch: str) -> bool:
         """Return True if an open doc-update PR already exists for *base_branch*.

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -148,6 +148,68 @@ class TestGitHubClient:
             }
         ]
 
+    def test_get_html_files_in_dirs_recurses_into_subdirs(self):
+        """HTML files in nested sub-directories must be discovered, not just the top level."""
+        from ai_reviewer.github.client import GitHubClient
+
+        def _item(path, item_type):
+            it = MagicMock()
+            it.type = item_type
+            it.path = path
+            return it
+
+        tree = {
+            "architecture": [
+                _item("architecture/index.html", "file"),
+                _item("architecture/concepts.html", "file"),
+                _item("architecture/styles.css", "file"),
+                _item("architecture/crates", "dir"),
+            ],
+            "architecture/crates": [
+                _item("architecture/crates/node.html", "file"),
+                _item("architecture/crates/auth.html", "file"),
+            ],
+        }
+
+        def _get_contents(lookup, ref):
+            assert ref == "abc123"  # ref must propagate through the recursion
+            return tree[lookup]
+
+        mock_repo = MagicMock()
+        mock_repo.get_contents.side_effect = _get_contents
+
+        with patch("ai_reviewer.github.client.Github"):
+            client = GitHubClient(token="test-token")
+            client._gh = MagicMock()
+            client._gh.get_repo.return_value = mock_repo
+            result = client.get_html_files_in_dirs("o/r", "abc123", ["architecture/"])
+
+        # Sorted, de-duplicated, and includes the nested crate pages.
+        assert result == [
+            "architecture/concepts.html",
+            "architecture/crates/auth.html",
+            "architecture/crates/node.html",
+            "architecture/index.html",
+        ]
+
+    def test_get_html_files_in_dirs_reraises_403(self):
+        """A 403 anywhere in the walk must surface as PermissionError, not be swallowed."""
+        from github.GithubException import GithubException
+
+        from ai_reviewer.github.client import GitHubClient
+
+        mock_repo = MagicMock()
+        mock_repo.get_contents.side_effect = GithubException(
+            status=403, data={"message": "Forbidden"}, headers={}
+        )
+
+        with patch("ai_reviewer.github.client.Github"):
+            client = GitHubClient(token="test-token")
+            client._gh = MagicMock()
+            client._gh.get_repo.return_value = mock_repo
+            with pytest.raises(PermissionError):
+                client.get_html_files_in_dirs("o/r", "abc123", ["architecture/"])
+
 
 class TestGitHubPRHandler:
     """Tests for PR event handling."""


### PR DESCRIPTION
## Problem

`GitHubClient.get_html_files_in_dirs` — the scanner that feeds the `update-docs` HTML path — only listed files **directly inside** each configured `static_docs_dir`. Nested pages were silently skipped.

Concretely, for `calimero-network/core` (`static_docs_dirs: [architecture/]`), the repo has:

```
architecture/concepts.html          ✅ scanned
architecture/config-reference.html   ✅ scanned
architecture/crates/node.html        ❌ never scanned
architecture/crates/auth.html        ❌ never scanned
architecture/crates/context.html     ❌ never scanned   (9 crate pages total)
```

So a PR that changes the `node` crate could never produce an update to `architecture/crates/node.html` — the most relevant page — because the scanner never saw it. Auto-docs effectively ignored the entire `crates/` subtree.

## Fix

Walk each configured directory **depth-first** with `get_contents`, pushing sub-directories onto a stack as they're discovered.

- **Bounded cost:** one API call per (sub)directory, scoped to the doc dirs passed in — *never* the whole repo. This is deliberately preferred over a single recursive `get_git_tree(recursive=True)` call, which can return `truncated: true` on large repos (core has thousands of files) and would silently drop entries.
- Results are now **sorted and de-duplicated**, so overlapping `dirs` can't yield the same page twice and ordering is stable.
- Error handling unchanged: **403 → `PermissionError`**; 404 on a missing dir is swallowed and the walk continues.

## Tests

- `test_get_html_files_in_dirs_recurses_into_subdirs` — nested `crates/*.html` discovered; non-HTML (`.css`) excluded; output sorted; `ref` propagates through the recursion.
- `test_get_html_files_in_dirs_reraises_403` — a 403 anywhere in the walk surfaces as `PermissionError`.

`ruff check` / `ruff format` clean; `mypy` clean; full `tests/test_github.py` green (96 passed).

## Context

Found while diagnosing why AutoDocs produced no / poor PRs in `core`. The primary cause there was a stale pinned SHA (fixed in calimero-network/core#2751); this is the secondary coverage gap on the tool side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to doc HTML discovery in GitHubClient with added unit tests; no auth or review-path changes, only more GitHub API calls per subdirectory under configured doc dirs.
> 
> **Overview**
> **`GitHubClient.get_html_files_in_dirs`** now walks each configured static docs directory **depth-first** via repeated `get_contents` calls, so nested `.html` pages (e.g. under `architecture/crates/`) are included in the auto-docs scan—not only files in the top level of each dir.
> 
> Results are collected in a **set** and returned **sorted** for stable, de-duplicated paths when `dirs` overlap. **403** still becomes **`PermissionError`**; missing paths are logged and skipped. Docstring updated to describe recursion and API cost.
> 
> **Tests** cover nested HTML discovery (non-HTML excluded, `ref` passed through) and 403 propagation during the walk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 347ef5eb4267baba2fea296926f1af1af712bf5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->