### PR TITLE
fix(anthropic): cap cache_control breakpoints to prevent 400s on long reviews

### DIFF
--- a/src/ai_reviewer/agents/anthropic_client.py
+++ b/src/ai_reviewer/agents/anthropic_client.py
@@ -174,23 +174,15 @@ class AnthropicClient:
                 )
 
             if self.config.enable_prompt_caching and tool_result_blocks:
-                # Use a single MOVING conversation breakpoint. Caching is a prefix
-                # match, so cache_control on the latest tool_result already caches
-                # the whole prefix up to this point — earlier breakpoints are
-                # redundant AND must be pruned: Anthropic caps a request at 4
-                # cache_control blocks, so leaving one per round would push
-                # system(1) + N tool rounds past the cap on the 5th round, a 400
-                # that silently drops the entire review. Strip prior breakpoints,
-                # then mark only the newest tool_result, keeping the per-request
-                # total at system(1) + conversation(1) = 2.
-                #
-                # Skip messages[0] — the caller's original user turn. We never set
-                # a breakpoint there (the ones we add live only on appended
-                # tool_result turns, all at index >= 1), so stripping it would only
-                # ever clobber a cache_control the caller deliberately placed. The
-                # in-place pop is safe precisely because every turn we touch here
-                # was constructed internally (serialized assistant blocks and
-                # tool_result dicts); no external reference to them is retained.
+                # Single MOVING breakpoint: caching is a prefix match, so
+                # cache_control on the latest tool_result caches everything before
+                # it — earlier breakpoints are redundant and must be pruned, else
+                # system(1) + one-per-round exceeds Anthropic's 4-per-request cap
+                # by the 5th round (a 400 that silently drops the whole review).
+                # Skip messages[0], the caller's user turn: we only ever mark
+                # appended tool_result turns (index >= 1), so the in-place pop
+                # touches only internally-built dicts and never clobbers a
+                # caller-supplied breakpoint.
                 for msg in messages[1:]:
                     content = msg.get("content")
                     if isinstance(content, list):

--- a/src/ai_reviewer/agents/anthropic_client.py
+++ b/src/ai_reviewer/agents/anthropic_client.py
@@ -183,7 +183,15 @@ class AnthropicClient:
                 # that silently drops the entire review. Strip prior breakpoints,
                 # then mark only the newest tool_result, keeping the per-request
                 # total at system(1) + conversation(1) = 2.
-                for msg in messages:
+                #
+                # Skip messages[0] — the caller's original user turn. We never set
+                # a breakpoint there (the ones we add live only on appended
+                # tool_result turns, all at index >= 1), so stripping it would only
+                # ever clobber a cache_control the caller deliberately placed. The
+                # in-place pop is safe precisely because every turn we touch here
+                # was constructed internally (serialized assistant blocks and
+                # tool_result dicts); no external reference to them is retained.
+                for msg in messages[1:]:
                     content = msg.get("content")
                     if isinstance(content, list):
                         for blk in content:

--- a/src/ai_reviewer/agents/anthropic_client.py
+++ b/src/ai_reviewer/agents/anthropic_client.py
@@ -174,11 +174,21 @@ class AnthropicClient:
                 )
 
             if self.config.enable_prompt_caching and tool_result_blocks:
-                # Cache the conversation prefix up to this point. Placing
-                # cache_control on the last tool_result block marks all prior
-                # messages as a cache breakpoint — the next round pays ~10%
-                # of normal input price for the accumulated history instead of
-                # re-billing it at full price every round.
+                # Use a single MOVING conversation breakpoint. Caching is a prefix
+                # match, so cache_control on the latest tool_result already caches
+                # the whole prefix up to this point — earlier breakpoints are
+                # redundant AND must be pruned: Anthropic caps a request at 4
+                # cache_control blocks, so leaving one per round would push
+                # system(1) + N tool rounds past the cap on the 5th round, a 400
+                # that silently drops the entire review. Strip prior breakpoints,
+                # then mark only the newest tool_result, keeping the per-request
+                # total at system(1) + conversation(1) = 2.
+                for msg in messages:
+                    content = msg.get("content")
+                    if isinstance(content, list):
+                        for blk in content:
+                            if isinstance(blk, dict):
+                                blk.pop("cache_control", None)
                 tool_result_blocks[-1] = dict(tool_result_blocks[-1])
                 tool_result_blocks[-1]["cache_control"] = {"type": "ephemeral"}
 

--- a/tests/test_anthropic_client.py
+++ b/tests/test_anthropic_client.py
@@ -303,6 +303,66 @@ async def test_caching_marks_last_tool_result_when_enabled():
     assert last_block_r3.get("cache_control") == {"type": "ephemeral"}
 
 
+def _count_cache_control(kwargs: dict) -> int:
+    """Count cache_control breakpoints across the system + messages of a single
+    messages.create payload — exactly what Anthropic caps at 4 per request."""
+    n = 0
+    system = kwargs.get("system")
+    if isinstance(system, list):
+        n += sum(1 for blk in system if isinstance(blk, dict) and "cache_control" in blk)
+    for msg in kwargs.get("messages", []):
+        content = msg.get("content")
+        if isinstance(content, list):
+            n += sum(1 for blk in content if isinstance(blk, dict) and "cache_control" in blk)
+    return n
+
+
+@pytest.mark.asyncio
+async def test_cache_control_breakpoints_never_exceed_four_across_tool_rounds():
+    """Regression for #67: cache_control breakpoints must not accumulate past the
+    Anthropic 4-per-request cap as the tool-use loop runs 5+ rounds.
+
+    Previously one breakpoint was appended per tool round and never pruned, so
+    system(1) + N accumulated tool-result breakpoints hit 5 on the 5th round and
+    the request was rejected with a 400 (silently dropping the whole review)."""
+    cfg = AnthropicApiConfig(api_key="sk-test", enable_prompt_caching=True)
+    client = AnthropicClient(cfg)
+    client._sdk = MagicMock()
+
+    # Snapshot the breakpoint count at call time — run_review reuses and mutates
+    # the same messages list across rounds, so inspecting await_args_list after
+    # the fact would only ever show the final state, not what each request sent.
+    counts: list[int] = []
+    counter = {"n": 0}
+
+    def fake_create(**kwargs):
+        counts.append(_count_cache_control(kwargs))
+        counter["n"] += 1
+        # Always request another tool round to drive the loop to its cap.
+        return _tool_use_response(f"t{counter['n']}", "read_file", {"path": "a.py"})
+
+    client._sdk.messages.create = AsyncMock(side_effect=fake_create)
+
+    registry = MagicMock()
+    registry.tool_specs.return_value = [{"name": "read_file", "input_schema": {}}]
+    registry.execute = AsyncMock(return_value="contents")
+
+    await client.run_review(
+        model="claude-sonnet-4-6",
+        system_blocks=[{"type": "text", "text": "s"}],
+        user_blocks=[{"type": "text", "text": "u"}],
+        output_schema={"type": "object"},
+        tool_registry=registry,
+        enable_thinking=False,
+        max_tokens=4096,
+        temperature=0.3,
+        max_tool_rounds=8,
+    )
+
+    assert len(counts) >= 6, f"expected the loop to run past 4 rounds, ran {len(counts)}"
+    assert max(counts) <= 4, f"cache_control breakpoints exceeded the 4-per-request cap: {counts}"
+
+
 @pytest.mark.asyncio
 async def test_caching_disabled_leaves_tool_result_unmarked():
     """When caching is off, no cache_control is added to tool_result blocks."""

--- a/tests/test_anthropic_client.py
+++ b/tests/test_anthropic_client.py
@@ -364,6 +364,96 @@ async def test_cache_control_breakpoints_never_exceed_four_across_tool_rounds():
 
 
 @pytest.mark.asyncio
+async def test_breakpoint_cap_holds_when_loop_terminates_normally():
+    """Companion to the cap regression: the loop runs 5+ tool rounds and then
+    ends with a real end_turn response (not the max_tool_rounds sentinel). The
+    breakpoint cap must hold on that path too, and the final review must parse."""
+    cfg = AnthropicApiConfig(api_key="sk-test", enable_prompt_caching=True)
+    client = AnthropicClient(cfg)
+    client._sdk = MagicMock()
+
+    counts: list[int] = []
+    counter = {"n": 0}
+
+    def fake_create(**kwargs):
+        counts.append(_count_cache_control(kwargs))
+        counter["n"] += 1
+        # Five tool rounds, then a normal completion on the sixth request.
+        if counter["n"] <= 5:
+            return _tool_use_response(f"t{counter['n']}", "read_file", {"path": "a.py"})
+        return _fake_response('{"findings": [], "summary": "done"}')
+
+    client._sdk.messages.create = AsyncMock(side_effect=fake_create)
+
+    registry = MagicMock()
+    registry.tool_specs.return_value = [{"name": "read_file", "input_schema": {}}]
+    registry.execute = AsyncMock(return_value="contents")
+
+    result = await client.run_review(
+        model="claude-sonnet-4-6",
+        system_blocks=[{"type": "text", "text": "s"}],
+        user_blocks=[{"type": "text", "text": "u"}],
+        output_schema={"type": "object"},
+        tool_registry=registry,
+        enable_thinking=False,
+        max_tokens=4096,
+        temperature=0.3,
+        max_tool_rounds=8,
+    )
+
+    assert len(counts) == 6, f"expected 5 tool rounds + 1 final request, got {len(counts)}"
+    assert max(counts) <= 4, f"cache_control breakpoints exceeded the 4-per-request cap: {counts}"
+    # The loop ended normally, so the real model output is parsed — not the cap sentinel.
+    assert result.parsed == {"findings": [], "summary": "done"}
+
+
+@pytest.mark.asyncio
+async def test_caller_user_block_cache_control_survives_tool_rounds():
+    """The strip pass prunes only the breakpoints the client adds to appended
+    tool_result turns — it must never strip a cache_control the caller placed on
+    the initial user turn. Guards the messages[1:] boundary (PR #68 review)."""
+    cfg = AnthropicApiConfig(api_key="sk-test", enable_prompt_caching=True)
+    client = AnthropicClient(cfg)
+    client._sdk = MagicMock()
+
+    # Snapshot at call time whether the original user turn still carries its
+    # caller-supplied breakpoint on every request.
+    user_cc_present: list[bool] = []
+    counter = {"n": 0}
+
+    def fake_create(**kwargs):
+        first_user_content = kwargs["messages"][0]["content"]
+        user_cc_present.append(
+            any(isinstance(b, dict) and "cache_control" in b for b in first_user_content)
+        )
+        counter["n"] += 1
+        if counter["n"] < 3:
+            return _tool_use_response(f"t{counter['n']}", "read_file", {"path": "a.py"})
+        return _fake_response('{"findings": [], "summary": "done"}')
+
+    client._sdk.messages.create = AsyncMock(side_effect=fake_create)
+
+    registry = MagicMock()
+    registry.tool_specs.return_value = [{"name": "read_file", "input_schema": {}}]
+    registry.execute = AsyncMock(return_value="contents")
+
+    await client.run_review(
+        model="claude-sonnet-4-6",
+        system_blocks=[{"type": "text", "text": "s"}],
+        user_blocks=[{"type": "text", "text": "u", "cache_control": {"type": "ephemeral"}}],
+        output_schema={"type": "object"},
+        tool_registry=registry,
+        enable_thinking=False,
+        max_tokens=4096,
+        temperature=0.3,
+    )
+
+    assert all(user_cc_present), (
+        f"caller's user-block cache_control was stripped: per-request presence={user_cc_present}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_caching_disabled_leaves_tool_result_unmarked():
     """When caching is off, no cache_control is added to tool_result blocks."""
     cfg = AnthropicApiConfig(api_key="sk-test", enable_prompt_caching=False)


### PR DESCRIPTION
## Summary

Fixes #67. The Anthropic tool-use loop in `anthropic_client.py` added one `cache_control` breakpoint **per tool round and never removed the previous ones**. They accumulated in `messages` and were all re-sent each request. Anthropic caps prompt caching at **4 `cache_control` breakpoints per request**, so any review that ran **5+ tool rounds** was rejected with a `400 invalid_request_error`.

Because the agent failed *silently* ("Not posting to GitHub"), affected PRs simply got **no AI review** — the only visible signal was a red `review` check. This had likely been silently skipping review on larger PRs for a while.

### Breakpoints per request, before the fix

| Request | system | tool-result | total |
|---|---|---|---|
| round 1 | 1 | 0 | 1 |
| round 4 | 1 | 3 | 4 (at cap) |
| round 5 | 1 | 4 | **5 → 400** |

## Fix

Use a single **moving** breakpoint instead of an accumulating one. Caching is a prefix match, so a `cache_control` on the *latest* `tool_result` already caches the whole prefix up to that point — earlier breakpoints are redundant. Before marking the new one, strip any prior `cache_control` from `messages`. This keeps the per-request total at `system(1) + conversation(1) = 2`, always within the cap regardless of tool-round count. The existing latest-`tool_result` caching invariant is preserved.

## Regression test

`test_cache_control_breakpoints_never_exceed_four_across_tool_rounds` drives the tool loop past 4 rounds with a stub SDK that always returns `stop_reason: "tool_use"` and asserts the number of `cache_control` blocks in **any single `messages.create` payload is ≤ 4**. The count is snapshotted at call time because `run_review` mutates the same `messages` list across rounds.

- **Before:** per-request counts `[1, 2, 3, 4, 5, 6, 7, 8, 9]` → fails (`9 > 4`).
- **After:** `[1, 2, 2, 2, …]` → passes.

## Verification

- `pytest tests/test_anthropic_client.py` — 12 passed (including the new test + existing caching invariants).
- Full suite — 461 passed.
- `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Anthropic review request path where a wrong strip boundary could break caching or drop reviews, but scope is narrow and well-covered by new tests.
> 
> **Overview**
> Fixes **silent review failures** on PRs that need **5+ tool rounds** when prompt caching is enabled. Each round used to add another `cache_control` on the latest `tool_result` without removing older ones, so `system(1) + N` breakpoints exceeded Anthropic’s **4-per-request** limit and `messages.create` returned **400**.
> 
> The tool-use loop now keeps a **single moving** conversation breakpoint: before tagging the newest `tool_result`, it strips `cache_control` from blocks in appended turns only (`messages[1:]`), so caller breakpoints on the initial user turn are left alone. Prefix caching behavior is unchanged—only the latest tool-result turn is marked.
> 
> Adds regression tests that snapshot per-request breakpoint counts (including normal completion and caller user-block `cache_control` preservation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d7a425fcd2b3b2bd207fb48cfe41ae771afe78d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->